### PR TITLE
Do not block winning call on race loser hangups

### DIFF
--- a/lib/call.js
+++ b/lib/call.js
@@ -3798,19 +3798,17 @@ class call {
       return this
     }
 
-    const hangups = []
     if( this.parent ) {
+      const hangups = []
       for( const child of this.parent.children ) {
         if( child !== this ) {
           child.detach()
-          /* do not await - we do not want to delay the winner in
-          connecting by waiting for the completion of the hangups */
           hangups.push( child.hangup( hangupcodes.LOSE_RACE ) )
         }
       }
+      /* do not block the winner - race losers complete in background */
+      Promise.all( hangups ).catch( ( e ) => console.error( e ) )
     }
-
-    await Promise.all( hangups )
     callstore.set( this )
 
     if ( this._dialog.sip )

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@babblevoice/babble-drachtio-callmanager",
-  "version": "3.7.30",
+  "version": "3.7.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@babblevoice/babble-drachtio-callmanager",
-      "version": "3.7.30",
+      "version": "3.7.31",
       "license": "MIT",
       "dependencies": {
         "@babblevoice/babble-drachtio-auth": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babblevoice/babble-drachtio-callmanager",
-  "version": "3.7.30",
+  "version": "3.7.31",
   "description": "Call processing to create a PBX",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Remove `await` on `Promise.all(hangups)` in `#onnewuacsuccess` so the winning call proceeds immediately to bridge/DTLS setup
- Race loser hangups complete in background with error catching
- Fixes ~2s delay before `remote()` is called on projectrtp, which was causing DTLS handshake timeouts for WebRTC clients

## Test plan
- [ ] Verify calls with multiple registrations still hang up losing legs
- [ ] Verify DTLS handshake completes faster for WebRTC clients
- [ ] Check no unhandled promise rejections in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)