### PR TITLE
Timeout not canceled on early media

### DIFF
--- a/lib/call.js
+++ b/lib/call.js
@@ -1973,6 +1973,16 @@ class call {
 
     if( options.early ) {
       this.state.early = true
+
+      /* The call is now progressing with early media. Cancel the ring (uac)
+         timeout: a far end that delivers early media (e.g. a carrier sending
+         183 Session Progress) and answers only after the ring timeout would
+         otherwise be torn down with a REQUEST_TIMEOUT (487) just before it
+         answers. Once the dialog is established the non-early answer path
+         clears this timer via #setdialog. */
+      clearTimeout( this._timers.newuac )
+      delete this._timers.newuac
+
       this._em.emit( "call.early", this )
       callmanager.options.em.emit( "call.early", this )
     } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@babblevoice/babble-drachtio-callmanager",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@babblevoice/babble-drachtio-callmanager",
-      "version": "3.8.0",
+      "version": "3.8.1",
       "license": "MIT",
       "dependencies": {
         "@babblevoice/babble-drachtio-auth": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babblevoice/babble-drachtio-callmanager",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "Call processing to create a PBX",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This appeared when some systems (in the reported example) the call went to voicemail - but requires 30 seconds. 20 seconds of early media (just ringing) leads to a timeout as it was not cancelled on early media.