### PR TITLE
Only yield around the mix when a connect hook is set (3.10.1)

### DIFF
--- a/lib/call.js
+++ b/lib/call.js
@@ -1354,12 +1354,19 @@ class call {
     /* When we adopt-and-mix (enterprise queues and ring groups connect this
        way rather than via #answerparent) we are the parent leg. preconnect
        runs before the mix (projectrtp cannot play into a mixing channel),
-       then we mix, then postconnect. */
+       then we mix, then postconnect. Only take the deferred (hook) path when a
+       hook is actually registered - otherwise mix synchronously in this tick,
+       exactly as before, so callers that assume the mix has been issued on
+       return (recording, queue setup) don't race a microtask. */
     if( mix ) {
-      this.#notifyconnecthook( this, other, "preconnect" )
-        .then( () => this.mix( other ) )
-        .then( () => this.#notifyconnecthook( this, other, "postconnect" ) )
-        .catch( ( e ) => console.trace( e ) )
+      if( this.callbacks && ( this.callbacks.preconnect || this.callbacks.postconnect ) ) {
+        this.#notifyconnecthook( this, other, "preconnect" )
+          .then( () => this.mix( other ) )
+          .then( () => this.#notifyconnecthook( this, other, "postconnect" ) )
+          .catch( ( e ) => console.trace( e ) )
+      } else {
+        this.mix( other )
+      }
     }
     return this
   }
@@ -1534,8 +1541,13 @@ class call {
     /* preconnect: our parent leg's handler runs BEFORE the mix. projectrtp
        cannot play audio into a channel that is being mixed, so a prompt that
        must be heard on connect is played to each leg separately here (both
-       channels are open by this point), then we mix. */
-    await this.#notifyconnecthook( this.parent, this, "preconnect" )
+       channels are open by this point), then we mix. Only yield when a hook is
+       actually registered - a normal bridge must mix synchronously in this tick
+       exactly as before, or recording/queue setup that assumes the mix has been
+       issued can race. */
+    if( this.parent.callbacks.preconnect ) {
+      await this.#notifyconnecthook( this.parent, this, "preconnect" )
+    }
 
     this.channels.audio.mix( this.parent.channels.audio )
 
@@ -1558,7 +1570,9 @@ class call {
       }
     }
 
-    await this.#notifyconnecthook( this.parent, this, "postconnect" )
+    if( this.parent.callbacks.postconnect ) {
+      await this.#notifyconnecthook( this.parent, this, "postconnect" )
+    }
 
     return this
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babblevoice/babble-drachtio-callmanager",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "description": "Call processing to create a PBX",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Regression in 3.10.0

3.10.0 (#157) added the `preconnect`/`postconnect` hooks, but wired them in a way that changed timing **even when no hook is registered**:

- `#answerparent` unconditionally `await`ed the preconnect hook *before* the synchronous `channels.audio.mix(...)`.
- `adopt()` deferred `this.mix(other)` into a `.then()` chain.

`await`ing a resolved promise (empty hook) still yields to the microtask queue, so a normal bridge now **yields before the mix**. Callers that assume the mix has been issued once the bridge returns — call recording, queue setup — race that microtask.

This regressed two babble-sip interface areas that were green on 3.9.0:
- `2.6.10.1/.2` netapi recording size-vs-duration
- `2.12.1.3/.4` call-queue xinfo (`atob` on an empty/malformed note)

Both were verified to pass on 3.9.0 and fail on 3.10.0 in isolation.

## Fix

Take the async hook path **only when a `preconnect`/`postconnect` hook is actually registered**; otherwise mix synchronously in the same tick, exactly as before 3.10.0. On-connect prompts (which do register a hook) are unaffected.

## Verification
- callmanager suite: 85 passing
- babble-sip: `2.6.10.1/.2` and `2.12.1.3/.4` recover; `2.19.21`/`2.19.22` (on-connect) still pass

## Release
Bumps to **3.10.1** — needs publishing (3.10.0 is already out with the regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)