### PR TITLE
fix(uac): cancel the settle watchdog on early media (183) so late answers connect

### DIFF
--- a/lib/call.js
+++ b/lib/call.js
@@ -4294,6 +4294,16 @@ class call {
               newcall._onring()
             } else if( 183 === res.status ) {
               earlypromise = newcall._onearly()
+              /* Early media: the far end is progressing (e.g. a carrier sending
+                 183 Session Progress that answers only after the ring timeout
+                 would fire). _onearly clears the ring timer (_timers.newuac);
+                 also clear the settle watchdog so it doesn't tear the call down
+                 with a REQUEST_TIMEOUT before the (late) answer arrives. The SIP
+                 transaction layer remains the backstop if it never answers. */
+              if( settlewatchdog ) {
+                clearTimeout( settlewatchdog )
+                settlewatchdog = undefined
+              }
             }
 
             if( newcall.canceled ) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babblevoice/babble-drachtio-callmanager",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "description": "Call processing to create a PBX",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Bug

A carrier that sends `183 Session Progress` (early media), rings past the UAC ring timeout, then answers, was torn down with a **`408 Request Timeout`** just before the answer arrived. (`babble-sip` `2.2.8.6`.)

## Root cause

`newuac` arms **two** timers at `uactimeout`:
- `_timers.newuac` — the ring timer.
- `settlewatchdog` — a watchdog that races `createUAC` and, at `settlems` (= `uactimeout`), calls `hangup(REQUEST_TIMEOUT)`.

Early media already cancels the ring timer (`_onearly()` → `answer({early:true})` → `clearTimeout(_timers.newuac)`). But `183` is provisional, so `createUAC` doesn't resolve and the race keeps running — **`settlewatchdog` still fires** at `uactimeout` and 408s the leg.

## Fix

Cancel `settlewatchdog` too when a `183` arrives (in `cbProvisional`). The SIP transaction layer (~32s) remains the backstop for a far end that delivers early media but never answers.

## Verification
- `babble-sip` `2.2.8.6` now connects (~5.5s, past the 2s ring timeout).
- Full `babble-sip` `2.2.8` real-world-issues suite: 6/6 (incl. `2.2.8.1`, 200-immediately-after-183).

Patch bump to **3.10.2**. babble-sip should bump its `@babblevoice/babble-drachtio-callmanager` dep to 3.10.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)